### PR TITLE
fix: accept arbitrary service endpoints

### DIFF
--- a/src/api/types/did-doc.ts
+++ b/src/api/types/did-doc.ts
@@ -17,7 +17,7 @@ const service = v
 	.object({
 		id: v.string(),
 		type: v.string(),
-		serviceEndpoint: v.union(urlString, v.record(urlString), v.array(urlString)),
+		serviceEndpoint: v.union(v.string(), v.record(v.string()), v.array(v.string())),
 	})
 	.chain((input) => {
 		switch (input.type) {

--- a/src/api/types/plc.ts
+++ b/src/api/types/plc.ts
@@ -20,7 +20,7 @@ const tombstoneOp = v.object({
 
 const service = v.object({
 	type: v.string().assert((input) => input.length <= 256, `service type too long (max 256)`),
-	endpoint: urlString.assert((input) => input.length <= 512, `service endpoint too long (max 512)`),
+	endpoint: v.string().assert((input) => input.length <= 512, `service endpoint too long (max 512)`),
 });
 export type Service = v.Infer<typeof service>;
 


### PR DESCRIPTION
They aren't guaranteed to be URLs, such as with `did:plc:tests5un2alniha5xkixhry4`.