### PR TITLE
feat: add download as json file to crypto-generate.tsx

### DIFF
--- a/src/views/crypto/crypto-generate.tsx
+++ b/src/views/crypto/crypto-generate.tsx
@@ -1,4 +1,4 @@
-import { createSignal, Show } from 'solid-js';
+import { createSignal, Show, createEffect } from 'solid-js';
 
 import { type DidKeyString, P256PrivateKeyExportable, Secp256k1PrivateKeyExportable } from '@atcute/crypto';
 
@@ -21,8 +21,18 @@ interface KeypairResult {
 const CryptoGeneratePage = () => {
 	const [type, setType] = createSignal<KeyType>('secp256k1');
 	const [result, setResult] = createSignal<KeypairResult>();
+	const [downloadUrl, setDownloadUrl] = createSignal<string | null>(null);
+	let downloadAnchorRef: HTMLAnchorElement | undefined;
 
 	useTitle(() => `Generate secret keys — boat`);
+
+	createEffect(() => {
+		// Cleanup blob URL when component unmounts or url changes
+		return () => {
+			const url = downloadUrl();
+			if (url) URL.revokeObjectURL(url);
+		};
+	});
 
 	return (
 		<>
@@ -104,6 +114,27 @@ const CryptoGeneratePage = () => {
 							<p class="font-semibold text-gray-600">Private key (multikey)</p>
 							<span class="font-mono">{/* @once */ keypair.privateMultikey}</span>
 						</div>
+					</div>
+				)}
+			</Show>
+			<Show when={result()} keyed>
+				{(keypair) => (
+					<div class="p-4">
+						<Button
+							type="button"
+							onClick={() => {
+								const dataStr = JSON.stringify(keypair, null, 2);
+								const dataUri = 'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
+								const link = document.createElement('a');
+								link.href = dataUri;
+								link.download = 'file.json';
+								document.body.appendChild(link);
+								link.click();
+								document.body.removeChild(link);
+							}}
+						>
+							Export as JSON
+						</Button>
 					</div>
 				)}
 			</Show>

--- a/src/views/crypto/crypto-generate.tsx
+++ b/src/views/crypto/crypto-generate.tsx
@@ -127,7 +127,7 @@ const CryptoGeneratePage = () => {
 								const dataUri = 'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
 								const link = document.createElement('a');
 								link.href = dataUri;
-								link.download = 'file.json';
+								link.download = 'secret_keys.json';
 								document.body.appendChild(link);
 								link.click();
 								document.body.removeChild(link);


### PR DESCRIPTION
This allows users to download generated secret keys as JSON files to make it easier to store generated secret keys.

<details>
<summary>Preview image</summary>

![](https://github.com/user-attachments/assets/eaa58bec-78b6-4fe8-bdcb-7d6b876595d0)

</details>

<details>
<summary>Example file</summary>

```json
{
  "type": "secp256k1",
  "publicDidKey": "did:key:zQ3shnm2mXFBJQ4iFKw27J9MTDKFng5C4oSjj6fZyfKiLHwzc",
  "privateHex": "950f4a4f652ba619094e57be434dbe7e461c8f20a22f2f73e3d51704382618bc",
  "privateMultikey": "z3vLe2kwGYJ4KWBcHXS28ymcRHKJNAEbbj63xcFPitYZAfV5"
}
```

</details>

- [x] Tested on Zen Browser (Firefox fork)