### PR TITLE
Add follower rule support to threadgate applicator

### DIFF
--- a/src/views/bluesky/threadgate-applicator/steps/step2_rules-input.tsx
+++ b/src/views/bluesky/threadgate-applicator/steps/step2_rules-input.tsx
@@ -178,6 +178,23 @@ const Step2_RulesInput = ({
 				</legend>
 
 				<ToggleInput
+					label="followers"
+					checked={hasThreadRule({ $type: 'app.bsky.feed.threadgate#followerRule' })}
+					onChange={(next) => {
+						if (next) {
+							setCustomThreadRules([
+								...(threadRules() ?? []),
+								{ $type: 'app.bsky.feed.threadgate#followerRule' },
+							]);
+						} else {
+							setCustomThreadRules(
+								threadRules()?.filter((rule) => rule.$type !== 'app.bsky.feed.threadgate#followerRule'),
+							);
+						}
+					}}
+				/>
+
+				<ToggleInput
 					label="followed users"
 					checked={hasThreadRule({ $type: 'app.bsky.feed.threadgate#followingRule' })}
 					onChange={(next) => {

--- a/src/views/bluesky/threadgate-applicator/utils.ts
+++ b/src/views/bluesky/threadgate-applicator/utils.ts
@@ -8,12 +8,10 @@ export const sortThreadgateAllow = (allow: ThreadgateState['allow']) => {
 			const aType = a.$type;
 			const bType = b.$type;
 
-			// Sort list rules alphabetically by list URI when comparing two list rules
 			if (aType === 'app.bsky.feed.threadgate#listRule' && aType === bType) {
 				return collator.compare(a.list, b.list);
 			}
 
-			// Sort all other rules alphabetically by type
 			return collator.compare(aType, bType);
 		});
 	}

--- a/src/views/bluesky/threadgate-applicator/utils.ts
+++ b/src/views/bluesky/threadgate-applicator/utils.ts
@@ -8,10 +8,12 @@ export const sortThreadgateAllow = (allow: ThreadgateState['allow']) => {
 			const aType = a.$type;
 			const bType = b.$type;
 
+			// Sort list rules alphabetically by list URI when comparing two list rules
 			if (aType === 'app.bsky.feed.threadgate#listRule' && aType === bType) {
 				return collator.compare(a.list, b.list);
 			}
 
+			// Sort all other rules alphabetically by type
 			return collator.compare(aType, bType);
 		});
 	}


### PR DESCRIPTION
This PR adds support for the `followerRule` threadgate option in the retroactive thread gating tool, allowing users to restrict post replies to only their followers.